### PR TITLE
Update gemspec path for new github org

### DIFF
--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -4,10 +4,10 @@ Gem::Specification.new do |s|
   s.summary     = 'Atomic CMS'
   s.description = 'Live CMS powered by atomic assets.'
   s.authors     = ['Don Humphreys', 'Spartan']
-  s.email       = 'spartan-helot@spartansystems.co'
+  s.email       = 'support@verypossible.com'
   s.files       = `git ls-files`.split(/\n/)
   s.test_files  = Dir['spec/**/*']
-  s.homepage    = 'https://github.com/spartansystems/atomic_cms'
+  s.homepage    = 'https://github.com/verypossible/atomic_cms'
   s.license     = 'MIT'
 
   s.add_dependency 'rails', '~> 4.2'

--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version     = '0.3.2'
   s.summary     = 'Atomic CMS'
   s.description = 'Live CMS powered by atomic assets.'
-  s.authors     = ['Don Humphreys', 'Spartan']
+  s.authors     = ['Don Humphreys', 'Very']
   s.email       = 'support@verypossible.com'
   s.files       = `git ls-files`.split(/\n/)
   s.test_files  = Dir['spec/**/*']


### PR DESCRIPTION
## Why?
`spartansystems` is no more, so the old link will eventually
become stale.

## What's changed:
**Refactor gemspec**
  Email and homepage updated.