### PR TITLE
Bump gemspec version

### DIFF
--- a/atomic_cms.gemspec
+++ b/atomic_cms.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'atomic_cms'
-  s.version     = '0.3.2'
+  s.version     = '0.3.3'
   s.summary     = 'Atomic CMS'
   s.description = 'Live CMS powered by atomic assets.'
   s.authors     = ['Don Humphreys', 'Spartan']


### PR DESCRIPTION
## Why?
Some changes to the gemspec need to be propagated to
RubyGems so that it's up-to-date.

## What's changed:
**Refactor gemspec**
  0.3.2 -> 0.3.3